### PR TITLE
Added test for libblosc / zarr

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -30,6 +30,7 @@ fi
 
 (bash configure --prefix=${PREFIX} \
                --host=${HOST} \
+               --with-libblosc=${PREFIX} \
                --with-curl \
                --with-dods-root=${PREFIX} \
                --with-expat=${PREFIX} \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -165,6 +165,8 @@ outputs:
         - {{ pin_compatible('numpy') }}
         - {{ pin_subpackage('libgdal', exact=True) }}
     test:
+      requires:
+        - zarr
       files:
         - test_data
         - extra_tests.py

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - disable_jpeg12.patch  # [win]
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:
@@ -23,6 +23,7 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
   host:
+    - blosc
     - cfitsio
     - curl
     - expat
@@ -76,6 +77,7 @@ outputs:
         - pkg-config  # [not win]
         - make  # [unix]
       host:
+        - blosc
         - cfitsio
         - curl
         - expat

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -85,6 +85,16 @@ def gen_list(N):
 N = 10
 assert list(gen_list(N)) == list(range(N))
 
+# https://github.com/conda-forge/gdal-feedstock/issues/567
+# test libblosc / zarr
+import zarr
+
+root = zarr.group("test.zarr/")
+z = root.zeroes("data", shape=(10, 10), chunks=(5, 5))
+
+ds = gdal.Open("test.zarr")
+assert ds.RasterXSize == 10
+
 # This module does some additional tests.
 import extra_tests
 


### PR DESCRIPTION
This is probably blocked by Zarr support for Python 3.10, which is blocked by https://github.com/conda-forge/numcodecs-feedstock/pull/78.